### PR TITLE
fix: replace `\` by `/` on Windows environment

### DIFF
--- a/person.py
+++ b/person.py
@@ -34,7 +34,7 @@ class University:
 
     @property
     def html(self):
-        return add_links(markdown_path(str(self.path / "index.md"), extras=markdown_extensions))
+        return add_links(markdown_path(self.path / "index.md", extras=markdown_extensions))
 
     def __repr__(self):
         return self.name

--- a/ssg.py
+++ b/ssg.py
@@ -47,11 +47,11 @@ def find_entries():
 
     for path in root.glob("**/*.md"):
         if path.stem == "index":  # university page
-            slug = str(path.relative_to(root).parent)
+            slug = path.relative_to(root).parent.as_posix()
             entries.append(page_entry(slug))
             entries.append(api_entry(f"api/{slug}"))
         else:
-            slug = str(path.relative_to(root).with_suffix(""))
+            slug = path.relative_to(root).with_suffix("").as_posix()
             entries.append(page_entry(slug))
             entries.append(api_entry(f"api/{slug}"))
 


### PR DESCRIPTION
and remove a useless `str()`